### PR TITLE
Replace deprecated color temp attributes

### DIFF
--- a/card.js
+++ b/card.js
@@ -203,8 +203,8 @@ class RGBLightCard extends HTMLElement {
         if (color['color_name']) {
             return color['color_name'];
         }
-        if (color['color_temp'] || color['kelvin']) {
-            let mireds = parseInt(color['color_temp'], 10) || Math.round(1000000 / parseInt(color['kelvin'], 10));
+        if (color['color_temp_kelvin']) {
+            let mireds = Math.round(1000000 / parseInt(color['color_temp_kelvin'], 10));
             mireds = Math.max(154, Math.min(500, mireds));
             const center = (500 + 154) / 2;
             const cr = [[166, 209, 255], [255, 255, 255], [255, 160, 0]].slice(mireds < center ? 0 : 1); // prettier-ignore


### PR DESCRIPTION
The color attributes `color_temp` and `kelvin` are deprecated and willl be removed in homeassistant `2026.1`. As they are removed, I'm removing them for the config and replace it by the new attribute `color_temp_kelvin`.

https://developers.home-assistant.io/blog/2024/12/14/kelvin-preferred-color-temperature-unit/
https://developers.home-assistant.io/docs/core/entity/light/

Fixes https://github.com/bokub/rgb-light-card/issues/87

As this is a breaking change (as old attributes won't work anymore), please list it in the release notes.